### PR TITLE
IDCOM-843 Support passing a map of non-standard clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,28 @@ by the verify() function, it must:
 These measures increase the security by reducing the likelihood
 that an attacker can either coerce the wallet owner to sign
 a transaction or intercept a broadcast one.
+
+## Configuration
+
+The prove and verify functions can be configured as follows:
+
+### `cluster`
+
+Default: `mainnet-beta`
+
+The cluster that should be used when generating and verifying proofs
+
+### `commitment`
+
+Default: `confirmed`
+
+When checking that a proof transaction has not been transmitted, the commitment to be used, i.e. the degree to which the transaction is finalised by the network
+
+### `supportedClusterUrls`
+
+Optional
+Default: empty
+
+If the cluster is not a standard solana public cluster, this map provides
+the cluster URL to connect to. Use this when the proof may contain a cluster that is
+not recognised by solana's clusterApiUrl function.

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import {
   SignCallback,
 } from './utilities';
 
-export { SignCallback } from './utilities';
+export { SignCallback, Config } from './utilities';
 
 export const prove = async (
   key: PublicKey | Keypair,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,4 @@
-import {
-  clusterApiUrl,
-  Connection,
-  Keypair,
-  PublicKey,
-  Transaction,
-} from '@solana/web3.js';
+import { Connection, Keypair, PublicKey, Transaction } from '@solana/web3.js';
 import {
   checkRecentBlock,
   checkSignatures,
@@ -13,6 +7,7 @@ import {
   Config,
   DEFAULT_CONFIG,
   defaultSigner,
+  getClusterUrl,
   isKeypair,
   makeTransaction,
   pubkeyOf,
@@ -32,10 +27,7 @@ export const prove = async (
     throw new Error('Provide either a keypair or a signer');
   const sign = signer || defaultSigner(key as Keypair);
 
-  const connection = new Connection(
-    clusterApiUrl(config.cluster),
-    config.commitment
-  );
+  const connection = new Connection(getClusterUrl(config), config.commitment);
 
   const publicKey = pubkeyOf(key);
 
@@ -65,7 +57,7 @@ export const verify = async (
 
   const transaction = Transaction.from(evidence);
 
-  const conn = new Connection(clusterApiUrl(config.cluster), config.commitment);
+  const conn = new Connection(getClusterUrl(config), config.commitment);
 
   const checkTransactionNotBroadcastPromise = checkTransactionNotBroadcast(
     conn,

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -29,9 +29,7 @@ export const pubkeyOf = (k: KeyMaterial): PublicKey =>
 export type ClusterUrlMap = Record<string, string>;
 
 export type Config = {
-  // the cluster that should be used when generating proofs
-  // and the default cluster used when verifying proofs, unless overridden
-  // in the proof itself
+  // the cluster that should be used when generating and verifying proofs
   cluster: string;
   // when checking that a proof transaction has not been transmitted, the commitment
   // to be used, i.e. the degree to which the transaction is finalised by the network


### PR DESCRIPTION
Allow the use of non-public solana clusters, or the overriding of the default solana API URLs to connect to the public clusters. See readme for details.