### PR TITLE
Optional block checking

### DIFF
--- a/scripts/prove.ts
+++ b/scripts/prove.ts
@@ -1,0 +1,23 @@
+import { Keypair } from '@solana/web3.js';
+import {Config, prove, verify} from '../src'
+import * as fs from "fs";
+import * as os from "os";
+
+const keypair = Keypair.fromSecretKey(Buffer.from(JSON.parse(fs.readFileSync(`${os.homedir()}/.config/solana/id.json`, { encoding: 'utf-8'}))));
+
+(async () => {
+  const config: Config = {
+    cluster: 'mainnet-beta',
+    commitment: 'confirmed',
+    supportedClusterUrls: {
+      'mainnet-beta': 'https://solflarew9wyt3yf6u.main.genesysgo.net:8899/'//https://rough-misty-night.solana-mainnet.quiknode.pro/0e5b8044efa931baf6eb130ff4798fb84af114d3/'
+    }
+  };
+  const proof = await prove(keypair, undefined);
+
+  console.log("Wallet: " + keypair.publicKey.toBase58());
+  console.log("Proof: " + proof.toString('base64'));
+
+  const verified = await verify(proof, keypair.publicKey, config).then(() => true);
+  console.log("Verified: " + verified)
+})();

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,9 @@ export const verify = async (
     conn,
     transaction
   );
-  const checkBlockPromise = checkRecentBlock(conn, transaction);
+  const checkBlockPromise = config.recentBlockCheck
+    ? checkRecentBlock(conn, transaction)
+    : Promise.resolve();
 
   await Promise.all([checkTransactionNotBroadcastPromise, checkBlockPromise]);
 };

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -38,12 +38,17 @@ export type Config = {
   // the cluster URL to connect to. Use this when the proof may contain a cluster that is
   // not recognised by solana's clusterApiUrl function
   supportedClusterUrls?: ClusterUrlMap;
+  // If true, check that the transaction includes a recent blockhash.
+  // Disable if nodes are having difficulty synchronising,
+  // warning - this makes replay attacks easier as proofs remain valid longer
+  recentBlockCheck: boolean;
 };
 
 export const DEFAULT_CONFIG: Config = {
   cluster: 'mainnet-beta',
   commitment: 'confirmed',
   supportedClusterUrls: {},
+  recentBlockCheck: true,
 };
 
 // get the solana cluster URL to connect to. Use the cluster in the config,


### PR DESCRIPTION
 In order to allow for proof verification against nodes that may not be in sync, make recent block checking optional