### PR TITLE
Feature/cpass 215  create verify with sign message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Prove-Solana-Wallet
+# prove-solana-wallet
 
-This library proves ownership of a [Solana](https://solana.com) wallet to off-chain verifiers.
+This library proveTransactions ownership of a [Solana](https://solana.com) wallet to off-chain verifiers.
 
 It is compatible with standard browser wallet adapters, such as 
 [sol-wallet-adapter](https://github.com/project-serum/sol-wallet-adapter), 
@@ -20,9 +20,9 @@ yarn add @identity.com/prove-solana-wallet
 
 ## Usage
 
-### Prove ownership of a keypair using a signed message
+### prove ownership of a keypair using a signed message
 
-Prover side: 
+prover side: 
 ```js
 const {create} = require('@identity.com/prove-solana-wallet');
 const nonce = new Date();
@@ -35,12 +35,12 @@ const {verify} = require('@identity.com/prove-solana-wallet');
 await verify(expectedPublicKey, proof);
 ```
 
-### Prove ownership of a keypair using a transaction
+### prove ownership of a keypair using a transaction
 
-Prover side: 
+prover side: 
 ```js
-const {prove} = require('@identity.com/prove-solana-wallet');
-const proof = await prove(myKeypair);
+const {proveTransaction} = require('@identity.com/prove-solana-wallet');
+const proof = await proveTransaction(myKeypair);
 ```
 
 Verifier side:
@@ -49,12 +49,12 @@ const {verifyTransaction} = require('@identity.com/prove-solana-wallet');
 await verifyTransaction(proof, expectedPublicKey);
 ```
 
-Prove ownership of an external wallet (e.g. sol-wallet-adapter).
+prove ownership of an external wallet (e.g. sol-wallet-adapter).
 See [here](https://github.com/project-serum/sol-wallet-adapter) for more details.
 
-Prover side:
+prover side:
 ```js
-const {prove} = require('@identity.com/prove-solana-wallet');
+const {proveTransaction} = require('@identity.com/prove-solana-wallet');
 import Wallet from "@project-serum/sol-wallet-adapter";
 
 const providerUrl = 'https://www.sollet.io';
@@ -63,7 +63,7 @@ wallet.on('connect', async (publicKey) => {
   // once the wallet is connected, we can prove ownership
   const signer = (transaction:Transaction) => wallet.signTransaction(transaction);
 
-  const proof = await prove(myKeypair);
+  const proof = await proveTransaction(myKeypair);
 });
 ```
 
@@ -81,7 +81,7 @@ The create(signMessageFn, message) function signs a message with the provided si
 The verify(publicKey, proof) function decodes the message and signature from the proof, and uses nacl to verify that the given public key signed the proof.
 
 ### Using a zero-value transaction
-The prove() function generates a zero-value transaction, and
+The proveTransaction() function generates a zero-value transaction, and
 signs it with the wallet private key. For the transaction to be verified
 by the verifyTransaction() function, it must:
 
@@ -97,7 +97,7 @@ a transaction or intercept a broadcast one.
 
 ## Configuration
 
-The prove and verifyTransaction functions can be configured as follows:
+The proveTransaction and verifyTransaction functions can be configured as follows:
 
 ### `cluster`
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,22 @@ yarn add @identity.com/prove-solana-wallet
 
 ## Usage
 
-Prove ownership of a keypair
+### Prove ownership of a keypair using a signed message
+
+Prover side: 
+```js
+const {create} = require('@identity.com/prove-solana-wallet');
+const nonce = new Date();
+const proof = await create(myKeypair, nonce);
+```
+
+Verifier side:
+```js
+const {verify} = require('@identity.com/prove-solana-wallet');
+await verify(expectedPublicKey, proof);
+```
+
+### Prove ownership of a keypair using a transaction
 
 Prover side: 
 ```js
@@ -30,8 +45,8 @@ const proof = await prove(myKeypair);
 
 Verifier side:
 ```js
-const {verify} = require('@identity.com/prove-solana-wallet');
-await verify(proof, expectedPublicKey);
+const {verifyTransaction} = require('@identity.com/prove-solana-wallet');
+await verifyTransaction(proof, expectedPublicKey);
 ```
 
 Prove ownership of an external wallet (e.g. sol-wallet-adapter).
@@ -54,15 +69,21 @@ wallet.on('connect', async (publicKey) => {
 
 Verifier side:
 ```js
-const {verify} = require('@identity.com/prove-solana-wallet');
-await verify(proof, expectedPublicKey);
+const {verifyTransaction} = require('@identity.com/prove-solana-wallet');
+await verifyTransaction(proof, expectedPublicKey);
 ```
 
 ## Details
 
+### Using a signed message
+The create(signMessageFn, message) function signs a message with the provided signing function, then concatenates the message with the string, both in base64 encoded form, i.e. `${messageB64}.${signatureB64}`.
+
+The verify(publicKey, proof) function decodes the message and signature from the proof, and uses nacl to verify that the given public key signed the proof.
+
+### Using a zero-value transaction
 The prove() function generates a zero-value transaction, and
 signs it with the wallet private key. For the transaction to be verified
-by the verify() function, it must:
+by the verifyTransaction() function, it must:
 
 - have ony one instruction: SystemProgram.transfer
 - be zero-value
@@ -76,13 +97,13 @@ a transaction or intercept a broadcast one.
 
 ## Configuration
 
-The prove and verify functions can be configured as follows:
+The prove and verifyTransaction functions can be configured as follows:
 
 ### `cluster`
 
 Default: `mainnet-beta`
 
-The cluster that should be used when generating and verifying proofs
+The cluster that should be used when generating and verifyTransactioning proofs
 
 ### `commitment`
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.8",
+  "version": "0.2.9",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "@solana/web3.js": "^1.63.1",
-    "bs58": "^4.0.1"
+    "bs58": "^4.0.1",
+    "tweetnacl": "^1.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.1",
+  "version": "0.4.0-beta.1",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export const verify = async (
 
   return true;
 };
-export const prove = async (
+export const proveTransaction = async (
   key: PublicKey | Keypair,
   signer?: SignCallback,
   config: Config = DEFAULT_CONFIG

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,9 +17,7 @@ import nacl from 'tweetnacl';
 
 export { SignCallback, Config, DEFAULT_CONFIG } from './utilities';
 
-export type SignMessageFn =(
-  message: string
-) => Promise<Uint8Array>;
+export type SignMessageFn = (message: string) => Promise<Uint8Array>;
 
 export const create = async (
   signMessage: SignMessageFn,
@@ -35,13 +33,17 @@ export const create = async (
 
 export const verify = async (
   publicKey: PublicKey,
-  proof: string,
+  proof: string
 ): Promise<boolean> => {
   const [message, signature] = proof.split('.');
   const decodedSignature = Buffer.from(signature, 'base64');
   const decodedMessage = Buffer.from(message, 'base64');
 
-  const verified = nacl.sign.detached.verify(decodedMessage, decodedSignature, publicKey.toBytes())
+  const verified = nacl.sign.detached.verify(
+    decodedMessage,
+    decodedSignature,
+    publicKey.toBytes()
+  );
   if (!verified) {
     throw new Error('Invalid proof');
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,12 +1,13 @@
-import { prove, verify } from '../src';
+import { prove, verifyTransaction, create, verify, SignMessageFn } from '../src';
 import {
-  Keypair,
   Transaction,
   Connection,
   clusterApiUrl,
   PublicKey,
+  Keypair,
 } from '@solana/web3.js';
 import { Config, DEFAULT_CONFIG, makeTransaction } from '../src/utilities';
+import * as nacl from 'tweetnacl';
 
 describe('prove-solana-wallet', () => {
   afterEach(() => jest.restoreAllMocks());
@@ -18,182 +19,209 @@ describe('prove-solana-wallet', () => {
     DEFAULT_CONFIG.commitment
   );
 
+  let signMessageFn: SignMessageFn;
+  let message: string;
   beforeEach(() => {
+    
     myKeypair = Keypair.generate();
+    signMessageFn = (message: string) => Promise.resolve(nacl.sign.detached(Buffer.from(message), myKeypair.secretKey));
     DEFAULT_CONFIG.cluster = 'devnet';
+    message = new Date().getTime().toString();
+  });
+  describe('create and verify', () => {
+    it('creates a wallet ownership proof when a signer function is provided', async () => {
+      const proof = await create(signMessageFn, message);
+      expect(proof).toMatch(/.*\..*/); // the message is a base64 version of the signature concatenated with the message
+    });
+  
+    it('verifies wallet ownership with provided signer function', async () => {
+      myKeypair = Keypair.generate();
+      signMessageFn = (message: string) => Promise.resolve(nacl.sign.detached(Buffer.from(message), myKeypair.secretKey));
+      const proof = await create(signMessageFn, message);
+      await expect(verify(myKeypair.publicKey, proof)).resolves.not.toThrow();
+    });
+  
+    it('throws an error if the transaction is signed with a different key', async () => {
+      const someOtherKey = Keypair.generate();
+  
+      const proof = await create((message: string) => Promise.resolve(nacl.sign.detached(Buffer.from(message), someOtherKey.secretKey)), message);
+      await expect(verify(myKeypair.publicKey, proof)).rejects.toThrow();
+    });
   });
 
-  it('verifies wallet ownership with provided key', async () => {
-    const proof = await prove(myKeypair);
-    await expect(verify(proof, myKeypair.publicKey)).resolves.not.toThrow();
-  });
+  describe('prove and verifyTransaction', () => {
+    it('verifies wallet ownership with provided key', async () => {
+      const proof = await prove(myKeypair);
+      await expect(verifyTransaction(proof, myKeypair.publicKey)).resolves.not.toThrow();
+    });
 
-  it('proves ownership of an external wallet', async () => {
-    const externalWalletSignCallback = async (transaction: Transaction) => {
+    it('proves ownership of an external wallet', async () => {
+      const externalWalletSignCallback = async (transaction: Transaction) => {
+        transaction.sign(myKeypair);
+        return transaction;
+      };
+  
+      const proof = await prove(myKeypair.publicKey, externalWalletSignCallback);
+      await expect(verifyTransaction(proof, myKeypair.publicKey)).resolves.not.toThrow();
+    });
+
+    it('supports using a non-standard cluster url', async () => {
+      const config: Config = {
+        cluster: 'mynet',
+        commitment: 'confirmed',
+        supportedClusterUrls: {
+          // in this test, "mynet" is basically an alias for devnet, but it could be any cluster
+          mynet: 'https://api.devnet.solana.com/',
+        },
+        recentBlockCheck: true,
+        broadcastCheck: true,
+      };
+      const proof = await prove(myKeypair, undefined, config);
+      await expect(
+        verifyTransaction(proof, myKeypair.publicKey, config)
+      ).resolves.not.toThrow();
+    });
+
+    it('uses a passed-in-connection', async () => {
+      const config: Config = {
+        cluster: 'devnet',
+        commitment: 'confirmed',
+        connection: new Connection(clusterApiUrl('devnet'), 'confirmed'),
+        recentBlockCheck: true,
+        broadcastCheck: true,
+      };
+      const proof = await prove(myKeypair, undefined, config);
+      await expect(
+        verifyTransaction(proof, myKeypair.publicKey, config)
+      ).resolves.not.toThrow();
+    });
+
+    it('throws an error if the transaction is signed with a different key', async () => {
+      const someOtherKey = Keypair.generate().publicKey;
+  
+      const proof = await prove(myKeypair);
+      await expect(verifyTransaction(proof, someOtherKey)).rejects.toThrow();
+    });
+  
+    it('throws an error if the transaction is too old', async () => {
+      // A blockhash on mainnet from july 2021 (epoch 206)
+      const oldBlockhash = 'HsH8JCpHtNwo9LgMZcxA8g7DGQu7HQDcDGcCvJSM9iZZ';
+  
+      jest
+        .spyOn(Connection.prototype, 'getLatestBlockhash')
+        .mockImplementation(() =>
+          Promise.resolve({
+            blockhash: oldBlockhash,
+            lastValidBlockHeight: 12345,
+          })
+        );
+  
+      const proof = await prove(myKeypair);
+      await expect(verifyTransaction(proof, myKeypair.publicKey)).rejects.toThrow(
+        'Block was not found'
+      );
+    });
+  
+    it('allows an old transaction if recentBlockCheck is disabled', async () => {
+      // A blockhash on mainnet from july 2021 (epoch 206)
+      const oldBlockhash = 'HsH8JCpHtNwo9LgMZcxA8g7DGQu7HQDcDGcCvJSM9iZZ';
+  
+      const config = {
+        ...DEFAULT_CONFIG,
+        recentBlockCheck: false,
+      };
+  
+      jest
+        .spyOn(Connection.prototype, 'getRecentBlockhash')
+        .mockImplementation(() =>
+          Promise.resolve({
+            blockhash: oldBlockhash,
+            feeCalculator: { lamportsPerSignature: 0 },
+          })
+        );
+  
+      const proof = await prove(myKeypair);
+      await expect(
+        verifyTransaction(proof, myKeypair.publicKey, config)
+      ).resolves.not.toThrow();
+    });
+  
+    it('throws an error if the transaction amout is non-zero', async () => {
+      const amount = 100;
+      const transaction = await makeTransaction(
+        connection,
+        myKeypair.publicKey,
+        myKeypair.publicKey,
+        amount
+      );
       transaction.sign(myKeypair);
-      return transaction;
-    };
-
-    const proof = await prove(myKeypair.publicKey, externalWalletSignCallback);
-    await expect(verify(proof, myKeypair.publicKey)).resolves.not.toThrow();
-  });
-
-  it('supports using a non-standard cluster url', async () => {
-    const config: Config = {
-      cluster: 'mynet',
-      commitment: 'confirmed',
-      supportedClusterUrls: {
-        // in this test, "mynet" is basically an alias for devnet, but it could be any cluster
-        mynet: 'https://api.devnet.solana.com/',
-      },
-      recentBlockCheck: true,
-      broadcastCheck: true,
-    };
-    const proof = await prove(myKeypair, undefined, config);
-    await expect(
-      verify(proof, myKeypair.publicKey, config)
-    ).resolves.not.toThrow();
-  });
-
-  it('uses a passed-in-connection', async () => {
-    const config: Config = {
-      cluster: 'devnet',
-      commitment: 'confirmed',
-      connection: new Connection(clusterApiUrl('devnet'), 'confirmed'),
-      recentBlockCheck: true,
-      broadcastCheck: true,
-    };
-    const proof = await prove(myKeypair, undefined, config);
-    await expect(
-      verify(proof, myKeypair.publicKey, config)
-    ).resolves.not.toThrow();
-  });
-
-  it('throws an error if the transaction is signed with a different key', async () => {
-    const someOtherKey = Keypair.generate().publicKey;
-
-    const proof = await prove(myKeypair);
-    await expect(verify(proof, someOtherKey)).rejects.toThrow();
-  });
-
-  it('throws an error if the transaction is too old', async () => {
-    // A blockhash on mainnet from july 2021 (epoch 206)
-    const oldBlockhash = 'HsH8JCpHtNwo9LgMZcxA8g7DGQu7HQDcDGcCvJSM9iZZ';
-
-    jest
-      .spyOn(Connection.prototype, 'getLatestBlockhash')
-      .mockImplementation(() =>
-        Promise.resolve({
-          blockhash: oldBlockhash,
-          lastValidBlockHeight: 12345,
-        })
+  
+      const proof = transaction.serialize();
+  
+      await expect(verifyTransaction(proof, myKeypair.publicKey)).rejects.toThrow(
+        'The transaction must have zero value'
       );
-
-    const proof = await prove(myKeypair);
-    await expect(verify(proof, myKeypair.publicKey)).rejects.toThrow(
-      'Block was not found'
-    );
-  });
-
-  it('allows an old transaction if recentBlockCheck is disabled', async () => {
-    // A blockhash on mainnet from july 2021 (epoch 206)
-    const oldBlockhash = 'HsH8JCpHtNwo9LgMZcxA8g7DGQu7HQDcDGcCvJSM9iZZ';
-
-    const config = {
-      ...DEFAULT_CONFIG,
-      recentBlockCheck: false,
-    };
-
-    jest
-      .spyOn(Connection.prototype, 'getRecentBlockhash')
-      .mockImplementation(() =>
-        Promise.resolve({
-          blockhash: oldBlockhash,
-          feeCalculator: { lamportsPerSignature: 0 },
-        })
+    });
+  
+    it('throws an error if the transaction is not self-signed', async () => {
+      const someOtherKey = Keypair.generate().publicKey;
+      const transaction = await makeTransaction(
+        connection,
+        myKeypair.publicKey,
+        someOtherKey,
+        0
       );
-
-    const proof = await prove(myKeypair);
-    await expect(
-      verify(proof, myKeypair.publicKey, config)
-    ).resolves.not.toThrow();
-  });
-
-  it('throws an error if the transaction amout is non-zero', async () => {
-    const amount = 100;
-    const transaction = await makeTransaction(
-      connection,
-      myKeypair.publicKey,
-      myKeypair.publicKey,
-      amount
-    );
-    transaction.sign(myKeypair);
-
-    const proof = transaction.serialize();
-
-    await expect(verify(proof, myKeypair.publicKey)).rejects.toThrow(
-      'The transaction must have zero value'
-    );
-  });
-
-  it('throws an error if the transaction is not self-signed', async () => {
-    const someOtherKey = Keypair.generate().publicKey;
-    const transaction = await makeTransaction(
-      connection,
-      myKeypair.publicKey,
-      someOtherKey,
-      0
-    );
-    transaction.sign(myKeypair);
-
-    const proof = transaction.serialize();
-
-    await expect(verify(proof, myKeypair.publicKey)).rejects.toThrow(
-      'The transaction must be self-to-self'
-    );
-  });
-
-  // Skip to avoid rate-limiting on mainnet - TODO switch this one to devnet
-  it.skip('throws an error if the transaction was broadcast', async () => {
-    // this is a self-to-self transaction broadcast to mainnet in july 2021
-    const transactionPublicKey = new PublicKey(
-      '2B64EYBMqrPTHyqXWYeJYT4QmqVgwc4vQ7qbLrBJ6J6n'
-    );
-    const transaction =
-      'AfqmAU243f1RyJUeSCu9wNNivwAiO8QNmVKDA8biALn8CBCb6jFNT4WKvgtzl7kRnATr27lTEQNdmAQZVOm5BwkBAAECEXE2KXQBAW2MC9Y8dPoDnheiXINczzUNFGfMaNC79YsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADtvR4/w2jei6eOB72wd18W6ofvsMpMoGXvCZP0yP1g1AQECAAAMAgAAAAAAAAAAAAAA';
-    const proof = Buffer.from(transaction, 'base64');
-
-    // stub out the recent blockhash check with a valid recent blockhash
-    jest
-      .spyOn(Connection.prototype, 'getFeeCalculatorForBlockhash')
-      .mockImplementation(() =>
-        Promise.resolve({
-          value: { lamportsPerSignature: 0 },
-          context: { slot: 0 },
-        })
+      transaction.sign(myKeypair);
+  
+      const proof = transaction.serialize();
+  
+      await expect(verifyTransaction(proof, myKeypair.publicKey)).rejects.toThrow(
+        'The transaction must be self-to-self'
       );
-
-    await expect(verify(proof, transactionPublicKey)).rejects.toThrow(
-      'Transaction was broadcast!'
-    );
-  });
-
-  it('allows a broadcast transaction if broadcastCheck is disabled', async () => {
-    // this is a self-to-self transaction broadcast to mainnet in july 2021
-    const transactionPublicKey = new PublicKey(
-      '2B64EYBMqrPTHyqXWYeJYT4QmqVgwc4vQ7qbLrBJ6J6n'
-    );
-    const transaction =
-      'AfqmAU243f1RyJUeSCu9wNNivwAiO8QNmVKDA8biALn8CBCb6jFNT4WKvgtzl7kRnATr27lTEQNdmAQZVOm5BwkBAAECEXE2KXQBAW2MC9Y8dPoDnheiXINczzUNFGfMaNC79YsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADtvR4/w2jei6eOB72wd18W6ofvsMpMoGXvCZP0yP1g1AQECAAAMAgAAAAAAAAAAAAAA';
-    const proof = Buffer.from(transaction, 'base64');
-
-    const config = {
-      ...DEFAULT_CONFIG,
-      broadcastCheck: false,
-      recentBlockCheck: false,
-    };
-    await expect(
-      verify(proof, transactionPublicKey, config)
-    ).resolves.not.toThrow();
+    });
+  
+    // Skip to avoid rate-limiting on mainnet - TODO switch this one to devnet
+    it.skip('throws an error if the transaction was broadcast', async () => {
+      // this is a self-to-self transaction broadcast to mainnet in july 2021
+      const transactionPublicKey = new PublicKey(
+        '2B64EYBMqrPTHyqXWYeJYT4QmqVgwc4vQ7qbLrBJ6J6n'
+      );
+      const transaction =
+        'AfqmAU243f1RyJUeSCu9wNNivwAiO8QNmVKDA8biALn8CBCb6jFNT4WKvgtzl7kRnATr27lTEQNdmAQZVOm5BwkBAAECEXE2KXQBAW2MC9Y8dPoDnheiXINczzUNFGfMaNC79YsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADtvR4/w2jei6eOB72wd18W6ofvsMpMoGXvCZP0yP1g1AQECAAAMAgAAAAAAAAAAAAAA';
+      const proof = Buffer.from(transaction, 'base64');
+  
+      // stub out the recent blockhash check with a valid recent blockhash
+      jest
+        .spyOn(Connection.prototype, 'getFeeCalculatorForBlockhash')
+        .mockImplementation(() =>
+          Promise.resolve({
+            value: { lamportsPerSignature: 0 },
+            context: { slot: 0 },
+          })
+        );
+  
+      await expect(verifyTransaction(proof, transactionPublicKey)).rejects.toThrow(
+        'Transaction was broadcast!'
+      );
+    });
+  
+    it('allows a broadcast transaction if broadcastCheck is disabled', async () => {
+      // this is a self-to-self transaction broadcast to mainnet in july 2021
+      const transactionPublicKey = new PublicKey(
+        '2B64EYBMqrPTHyqXWYeJYT4QmqVgwc4vQ7qbLrBJ6J6n'
+      );
+      const transaction =
+        'AfqmAU243f1RyJUeSCu9wNNivwAiO8QNmVKDA8biALn8CBCb6jFNT4WKvgtzl7kRnATr27lTEQNdmAQZVOm5BwkBAAECEXE2KXQBAW2MC9Y8dPoDnheiXINczzUNFGfMaNC79YsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADtvR4/w2jei6eOB72wd18W6ofvsMpMoGXvCZP0yP1g1AQECAAAMAgAAAAAAAAAAAAAA';
+      const proof = Buffer.from(transaction, 'base64');
+  
+      const config = {
+        ...DEFAULT_CONFIG,
+        broadcastCheck: false,
+        recentBlockCheck: false,
+      };
+      await expect(
+        verifyTransaction(proof, transactionPublicKey, config)
+      ).resolves.not.toThrow();
+    });
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,4 @@
-import { prove, verifyTransaction, create, verify, SignMessageFn } from '../src';
+import { proveTransaction, verifyTransaction, create, verify, SignMessageFn } from '../src';
 import {
   Transaction,
   Connection,
@@ -49,19 +49,19 @@ describe('prove-solana-wallet', () => {
     });
   });
 
-  describe('prove and verifyTransaction', () => {
+  describe('proveTransaction and verifyTransaction', () => {
     it('verifies wallet ownership with provided key', async () => {
-      const proof = await prove(myKeypair);
+      const proof = await proveTransaction(myKeypair);
       await expect(verifyTransaction(proof, myKeypair.publicKey)).resolves.not.toThrow();
     });
 
-    it('proves ownership of an external wallet', async () => {
+    it('prove ownership of an external wallet', async () => {
       const externalWalletSignCallback = async (transaction: Transaction) => {
         transaction.sign(myKeypair);
         return transaction;
       };
   
-      const proof = await prove(myKeypair.publicKey, externalWalletSignCallback);
+      const proof = await proveTransaction(myKeypair.publicKey, externalWalletSignCallback);
       await expect(verifyTransaction(proof, myKeypair.publicKey)).resolves.not.toThrow();
     });
 
@@ -76,7 +76,7 @@ describe('prove-solana-wallet', () => {
         recentBlockCheck: true,
         broadcastCheck: true,
       };
-      const proof = await prove(myKeypair, undefined, config);
+      const proof = await proveTransaction(myKeypair, undefined, config);
       await expect(
         verifyTransaction(proof, myKeypair.publicKey, config)
       ).resolves.not.toThrow();
@@ -90,7 +90,7 @@ describe('prove-solana-wallet', () => {
         recentBlockCheck: true,
         broadcastCheck: true,
       };
-      const proof = await prove(myKeypair, undefined, config);
+      const proof = await proveTransaction(myKeypair, undefined, config);
       await expect(
         verifyTransaction(proof, myKeypair.publicKey, config)
       ).resolves.not.toThrow();
@@ -99,7 +99,7 @@ describe('prove-solana-wallet', () => {
     it('throws an error if the transaction is signed with a different key', async () => {
       const someOtherKey = Keypair.generate().publicKey;
   
-      const proof = await prove(myKeypair);
+      const proof = await proveTransaction(myKeypair);
       await expect(verifyTransaction(proof, someOtherKey)).rejects.toThrow();
     });
   
@@ -116,7 +116,7 @@ describe('prove-solana-wallet', () => {
           })
         );
   
-      const proof = await prove(myKeypair);
+      const proof = await proveTransaction(myKeypair);
       await expect(verifyTransaction(proof, myKeypair.publicKey)).rejects.toThrow(
         'Block was not found'
       );
@@ -140,7 +140,7 @@ describe('prove-solana-wallet', () => {
           })
         );
   
-      const proof = await prove(myKeypair);
+      const proof = await proveTransaction(myKeypair);
       await expect(
         verifyTransaction(proof, myKeypair.publicKey, config)
       ).resolves.not.toThrow();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
-  "include": ["src", "types"],
+  "include": ["src", "types", "test"],
   "compilerOptions": {
     "module": "esnext",
     "lib": ["dom", "esnext"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -8264,6 +8264,11 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
+tweetnacl@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
+  integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
+
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"


### PR DESCRIPTION
This PR implements create/verify functions using sign-message rather than zero-amount transactions. 

Legacy zero-amount transactions are still supported but using the functions proveTransaction/verifyTransaction: these can be used in (rare) cases where the wallet doesn't support signMessage